### PR TITLE
feat: allow core component attrs to be checked on components

### DIFF
--- a/slippers/conf.py
+++ b/slippers/conf.py
@@ -10,6 +10,19 @@ class Settings:
         return getattr(django_settings, "SLIPPERS_RUNTIME_TYPE_CHECKING", django_settings.DEBUG)  # type: ignore
 
     @property
+    def SLIPPERS_CORE_COMPONENT_ATTRS(self) -> str:
+        """Core component allowed attributes
+
+        By default, return the common HTMX attributes & id
+        """
+        return getattr(
+            django_settings,
+            "SLIPPERS_CORE_COMPONENT_ATTRS",
+            "id hx-get hx-post hx-on hx-push-url hx-select hx-select-oob hx-swap "
+            "hx-swap-oob hx-target hx-trigger hx-vals"
+        )
+
+    @property
     def SLIPPERS_OPEN_TAG_PREFIX(self) -> bool:
         """Prefix for component opening tags"""
         return getattr(django_settings, "SLIPPERS_OPEN_TAG_PREFIX", "qr-")

--- a/slippers/templatetags/slippers.py
+++ b/slippers/templatetags/slippers.py
@@ -210,6 +210,8 @@ class AttrsNode(template.Node):
 def do_attrs(parser, token):
     tag_name, *attrs = token.split_contents()
 
+    attrs = set(attrs) | set(settings.SLIPPERS_CORE_COMPONENT_ATTRS.split(" "))
+
     # Format all tokens to be attr=attr so we can use token_kwargs() on it
     all_attrs = [attr if "=" in attr else f"{attr}={attr}" for attr in attrs]
     attr_map = slippers_token_kwargs(all_attrs, parser)


### PR DESCRIPTION
Add the ability to have core attributes on components. This will make htmx easier to implement at the component level (though doesnt help with nested components that come baked in)
The existing `{% attrs %}` can be used even without any args, and will consider any default attributes defined in settings.

For example,

```
<button
    class="
        qr-c-btn
        {% if children %} qr-c-btn--i--custom{% endif %}
        {% if icon %} qr-c-btn--i-{{icon}}{% endif %}
        {% if size %} qr-c-btn--{{size}}{% endif %}
        {% if style %} qr-c-btn--{{style}}{% endif %}
        {% if class %}{{ class }}{% endif %}
    " {% attrs %}
>{% if children %}{{ children }}{% endif %}</button>
```

can be called with 
```
{% qr-button style=style icon=icon size=size class=class hx-get="/" hx-target="abc" id="mybtn" %}
```