### PR TITLE
chore: add setting to disable slippers checks

### DIFF
--- a/slippers/apps.py
+++ b/slippers/apps.py
@@ -8,6 +8,7 @@ from django.utils.autoreload import autoreload_started, file_changed
 
 import yaml
 
+from slippers.conf import settings
 from slippers.templatetags.slippers import register_components
 
 
@@ -43,6 +44,8 @@ def changed(sender, file_path: PosixPath, **kwargs):
 
 def checks(app_configs, **kwargs):
     """Warn if unable to find components.yaml"""
+    if settings.SLIPPERS_DISABLE_CHECKS:
+        return []
     try:
         get_components_yaml()
     except TemplateDoesNotExist:

--- a/slippers/conf.py
+++ b/slippers/conf.py
@@ -43,5 +43,10 @@ class Settings:
             ["console", "overlay"],
         )
 
+    @property
+    def SLIPPERS_DISABLE_CHECKS(self) -> bool:
+        """Disable checks for components.yaml"""
+        return getattr(django_settings, "SLIPPERS_DISABLE_CHECKS", True)
+
 
 settings = Settings()


### PR DESCRIPTION
no more of this (qromponents dynamically registers all components, so it's not relevant):
![image](https://github.com/user-attachments/assets/87c5bf65-309e-4fd8-b9f3-cb50564548bc)
